### PR TITLE
Update ControlType.FusedNumber docs

### DIFF
--- a/components/code.md
+++ b/components/code.md
@@ -294,8 +294,8 @@ The fused number control is specifically created for border-radius, border-width
 ```typescript
 interface FusedNumberControlDescription {
   type: ControlType.FusedNumber
-  splitKey: string
-  splitLabels: [string, string]
+  toggleKey: string
+  toggleTitles: [string, string]
   valueKeys: [string, string, string, string]
   valueLabels: [string, string, string, string]
   min?: number


### PR DESCRIPTION
Using the current keys triggers two console warning: 

```
Deprecation warning: splitKey option of FusedNumber control type will be removed in version 1.0.0, use toggleKey instead.
Deprecation warning: splitLabels option of FusedNumber control type will be removed in version 1.0.0, use toggleTitles instead.
```